### PR TITLE
Fix Qwen2.5-Omni fine‑tuning pipeline

### DIFF
--- a/qwen_ft/dataset.py
+++ b/qwen_ft/dataset.py
@@ -104,15 +104,16 @@ def tokenize_dataset(
             padding=True,
             use_audio_in_video=True,
         )
-        # print(inputs["input_ids"].shape)
-        # print(inputs["attention_mask"].shape)
-        # print(inputs["feature_attention_mask"].shape)
-        # print(inputs["input_features"].shape)
-        # exit()
 
-        return inputs
+        data = {k: v[0].tolist() for k, v in inputs.items()}
+        data["query"] = query
+        for key in ("severe_osa", "sr_level", "label"):
+            if key in sample:
+                data[key] = sample[key]
 
-    ds = raw_ds.map(process_function, batched=False, num_proc=4)
+        return data
+
+    ds = raw_ds.map(process_function, batched=False)
     return ds
 
 

--- a/qwen_omni_utils.py
+++ b/qwen_omni_utils.py
@@ -1,0 +1,23 @@
+from typing import List, Tuple
+
+
+def process_mm_info(conversation: List[dict], use_audio_in_video: bool = False) -> Tuple[List[str], List[str], List[str]]:
+    """Collect audio, image and video paths from a multimodal conversation."""
+    audios = []
+    images = []
+    videos = []
+    for message in conversation:
+        for item in message.get("content", []):
+            if not isinstance(item, dict):
+                continue
+            t = item.get("type")
+            if t == "audio":
+                audios.append(item.get("audio"))
+            elif t == "image":
+                images.append(item.get("image"))
+            elif t == "video":
+                if use_audio_in_video:
+                    videos.append(item.get("video"))
+                else:
+                    audios.append(item.get("video"))
+    return audios, images, videos

--- a/train.py
+++ b/train.py
@@ -284,20 +284,13 @@ def main(
                         attention_mask=attention_mask,
                         feature_attention_mask=feature_attention_mask,
                     )
-                    print(logits)
-                    exit()
                 all_logits.extend(logits.to(io_device))
                 pred_logging.extend(torch.argmax(F.softmax(logits, dim=-1), dim=-1))
                 all_labels.extend(labels)
                 label_logging.extend(labels)
 
-            print(all_labels)
-            print(all_logits)
             all_logits = torch.stack(all_logits)
             all_labels = torch.stack(all_labels)
-            print(all_labels)
-            print(all_logits)
-            exit()
             loss = loss_fn(all_logits, all_labels)
             loss_batch += loss.item()
             scaler.scale(loss).backward()


### PR DESCRIPTION
## Summary
- implement `qwen_omni_utils.process_mm_info`
- rewrite dataset tokenizer to return serializable features
- simplify TransformerWithHead forward for gradient flow
- clean up training loop from debug exits

## Testing
- `python -m py_compile qwen_ft/*.py train.py qwen_omni_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6888577c61bc833098e1d925c01d7676